### PR TITLE
Add missing import in Python example

### DIFF
--- a/code-examples.rst
+++ b/code-examples.rst
@@ -93,6 +93,7 @@ Inserting a single entry
 		.. code-block:: python
 			
 			import requests
+			from requests.auth import HTTPBasicAuth
 			url = 'https://app.logsentinel.com/api/log/' + actorId + '/' + action + '/' + entityType + '/' + entityId;
 			data = '''{
 			  "detail1": "detail 1",


### PR DESCRIPTION
Reference - https://requests.readthedocs.io/en/master/user/authentication/

Feel free to close my PR & just add it via commit :v: